### PR TITLE
Add handling of format query param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 *.egg-info
 dist
 build
+~build
 eggs
 parts
 bin

--- a/src/drf_querystringfilter/backend.py
+++ b/src/drf_querystringfilter/backend.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 
 # from django.core.exceptions import FieldDoesNotExist
+from django.conf import settings
 from django.db.models import BooleanField, CharField
 from rest_framework.filters import BaseFilterBackend
 
@@ -20,6 +21,15 @@ class QueryStringFilterBackend(BaseFilterBackend):
         More semantically correct name for request.GET.
         """
         return self.request._request.GET
+
+    @property
+    def excluded_query_params(self):
+        params_list = ['_distinct']
+        format_param = "format"
+        if hasattr(settings, "URL_FORMAT_OVERRIDE"):
+            format_param = settings.URL_FORMAT_OVERRIDE
+        params_list.append(format_param)
+        return params_list
 
     def ignore_filter(self, request, field, view):
         if hasattr(view, 'drf_ignore_filter'):
@@ -68,7 +78,7 @@ class QueryStringFilterBackend(BaseFilterBackend):
                 mapping = {}
             opts = queryset.model._meta
             for fieldname_arg in self.query_params:
-                if fieldname_arg in ['_distinct']:
+                if fieldname_arg in self.excluded_query_params:
                     continue
                 try:
                     value = self.query_params.getlist(fieldname_arg)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -81,6 +81,27 @@ def test_processor_operator(backend, view, rf, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_format(backend, view, rf, monkeypatch):
+    request = Request(rf.get('/aaa/?format=csv'))
+    monkeypatch.setattr(view, 'filter_fields', ['id'])
+    record(id=1)
+
+    qs = backend.filter_queryset(request, view.queryset, view)
+    assert list(qs.values('id')) == [{'id': 1}]
+
+
+@pytest.mark.django_db
+def test_format_override(backend, view, rf, monkeypatch, settings):
+    settings.URL_FORMAT_OVERRIDE = "f"
+    request = Request(rf.get('/aaa/?f=csv'))
+    monkeypatch.setattr(view, 'filter_fields', ['id'])
+    record(id=1)
+
+    qs = backend.filter_queryset(request, view.queryset, view)
+    assert list(qs.values('id')) == [{'id': 1}]
+
+
+@pytest.mark.django_db
 def test_equal1(backend, view, rf, monkeypatch):
     request = Request(rf.get('/aaa/?id=1'))
     monkeypatch.setattr(view, 'filter_fields', ['id'])


### PR DESCRIPTION
Tweak to handle query parameter formats http://www.django-rest-framework.org/api-guide/format-suffixes/#query-parameter-formats